### PR TITLE
Remove './' from beginning of file paths, it's unnecessary and breaks th...

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -3,8 +3,8 @@ var EventEmitter = require('events').EventEmitter;
 var LessFile = require('./lessfile');
 
 function Manager(srcDir, dstDir) {
-  this.srcDir = srcDir;
-  this.dstDir = dstDir;
+  this.srcDir = srcDir.replace(/^.\//, '');
+  this.dstDir = dstDir.replace(/^.\//, '');
   this.files = {};
   this.dependencies = {};
   this.pending = 0;


### PR DESCRIPTION
...e file name creation logic

This should close #3 -- turns out the problem was caused if you try to pass './' in the srcDir or dstDir arguments. You could just tell people not to do that, but if you just run those vars through a quick `.remove()` to remove opening './' from either argument, the problem seems to be solved no matter what.
