### PR TITLE
Fixing the case where a user enters a single '.' as a CLI argument

### DIFF
--- a/bin/autoless
+++ b/bin/autoless
@@ -18,17 +18,9 @@ program
 var srcDir = program.args[0] || process.cwd();
 var dstDir = program.args[1] || srcDir;
 
+// Replace a single '.' input as process.cwd() which is what they meant
 srcDir = srcDir.replace(/^\.$/, process.cwd());
 dstDir = dstDir.replace(/^\.$/, process.cwd());
-
-
-console.log('==========');
-
-console.log('srcdir', srcDir);
-console.log('dstdir', dstDir);
-
-console.log('==========');
-
 
 var monitorOptions = {
   interval: program.interval


### PR DESCRIPTION
This is related to jgonera/autoless#4 and jgonera/autoless#5

We got this _almost_ fixed 6 months ago, but I ran into it again today without thinking because my solution didn't cover the use case of:

``` bash
$ autoless .
```

It was difficult to fix this at the same place as in manager.js as I did in #4, and since I think this is probably a pretty CLI-unique case, I dropped into the bin exec file and swapped it there before it passes args to the manager object. 

It definitely fixes the problem I was having—thoughts?
