### PR TITLE
Update watch to 0.14.0 to unwatch temporary files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "engines": { "node": ">= 0.8.x" },
   "repository": { "type": "git", "url": "https://github.com/jgonera/autoless.git" },
   "dependencies": {
-    "watch": "0.9.0",
+    "watch": "0.14.0",
     "growl": "1.7.0",
     "commander": "2.1.0",
     "less": "1.7.5"


### PR DESCRIPTION
It'll fix the problem that try to access an already removed file (e.g. vim temporary file) after it's added to watch in the watch v0.9.0.