### PR TITLE
Use node-notifier instead of growl for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Another .less file watcher, but this time with:
 
 * Dependency tracking (if a file imported by other files changes, they get
   compiled).
-* Growl notifications (a notification with summary shows up after each time
+* Cross-platform notifications via [node-notifier](https://www.npmjs.com/package/node-notifier) (a notification with summary shows up after each time
   something is compiled).
 
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Usage
         -h, --help               output usage information
         --interval <ms>          How often files are checked for changes
         --no-watch               Compile what needs to be compiled and exit
+        --no-notify              Do not send any notifications
+        --no-sound               Do not play a sound with error notifications
         --source-map             Generate source map files next to css files
         --autoprefix <browsers>  Browserslist query, e.g. '> 1%, last 2 versions'
         --compile-imports        Compile imported files, not just the files that import them

--- a/bin/autoless
+++ b/bin/autoless
@@ -4,7 +4,7 @@
 var path = require('path');
 var util = require('util');
 var watch = require('watch');
-var growl = require('growl');
+var notifier = require('node-notifier');
 var program = require('commander');
 var less = require('less');
 var Manager = require('../lib/manager');
@@ -13,6 +13,8 @@ program
   .usage('[options] <source_dir> [destination_dir]')
   .option('--interval <ms>', 'How often files are checked for changes', 100)
   .option('--no-watch', "Compile what needs to be compiled and exit")
+  .option('--no-notify', "Do not send any notifications")
+  .option('--no-sound', "Do not play a sound with error notifications")
   .option('--source-map', "Generate source map files next to css files")
   .option('--autoprefix <browsers>', "Browserslist query, e.g. '> 1%, last 2 versions'")
   .option('--compile-imports', "Compile imported files, not just the files that import them")
@@ -76,9 +78,11 @@ function notify(summary) {
     result === 'success' ? summary.length : message.length
   ));
 
-  growl(message.join('\n'), {
+  notifier.notify({
     title: 'LESS',
-    image: path.join(__dirname, '../images', result + '.svg')
+    message: message.join('\n'),
+    icon: path.join(__dirname, '../images', result + '.svg'),
+    sound: program.sound && result === 'error'
   });
 }
 
@@ -117,7 +121,7 @@ watch.createMonitor(srcDir, monitorOptions, function(monitor) {
       monitor.on('created', check);
       monitor.on('removed', manager.remove.bind(manager));
 
-      manager.on('checkSummary', notify);
+      if (program.notify) manager.on('checkSummary', notify);
 
       console.log('Monitoring files in ' + srcDir);
     });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "growl": "1.7.0",
     "commander": "2.1.0",
     "less": "1.7.5",
-    "autoprefixer-core": "5.1.7"
+    "autoprefixer-core": "5.1.7",
+    "node-notifier": "^4.2.1"
   },
   "devDependencies": {
     "jshint": "*",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "repository": { "type": "git", "url": "https://github.com/jgonera/autoless.git" },
   "dependencies": {
     "watch": "0.14.0",
-    "growl": "1.7.0",
     "commander": "2.1.0",
     "less": "1.7.5",
     "autoprefixer-core": "5.1.7",


### PR DESCRIPTION
What do you think of using node-notifier instead of growl? It's cross-platform compatible and falls back to growl. 

I also added a couple of cli options, let me know what you think.